### PR TITLE
Feature/#10 vts process

### DIFF
--- a/src/constants/static.ts
+++ b/src/constants/static.ts
@@ -2,4 +2,7 @@ export default {
   what: ` VTS(Visual Thinking Strategies)는 인지심리학자 하우젠(Abigail Housen)과 MoMA의
   미술관 에듀케이터 (Director of Education)였던 예나윈(Philip Yenawine)에 의해 개발된 질문 기반
   교수법입니다.`,
+  first: "이 그림에서 무슨 일이 일어나고 있나요?",
+  second: "무엇을 보고 그렇게 말했나요?",
+  third: "또 무엇을 더 찾을 수 있나요?",
 };

--- a/src/constants/static.ts
+++ b/src/constants/static.ts
@@ -1,8 +1,9 @@
 export default {
-  what: ` VTS(Visual Thinking Strategies)는 인지심리학자 하우젠(Abigail Housen)과 MoMA의
-  미술관 에듀케이터 (Director of Education)였던 예나윈(Philip Yenawine)에 의해 개발된 질문 기반
-  교수법입니다.`,
-  first: "이 그림에서 무슨 일이 일어나고 있나요?",
-  second: "무엇을 보고 그렇게 말했나요?",
-  third: "또 무엇을 더 찾을 수 있나요?",
+  what: `Visual Thinking Strategies (VTS) is a question-based methodology developed by cognitive psychologist Abigail Housen and MoMA's
+  Philip Yenawine, formerly the Director of Education at MoMA.
+  teaching methodology.`,
+  first: "What's going on in this picture?",
+  second: "What did you see that made you say that?",
+  third: "What else can you find?",
+  evaluate: "All VTS sessions have ended. Please rate your VTS session.",
 };

--- a/src/controllers/post.ts
+++ b/src/controllers/post.ts
@@ -13,27 +13,33 @@ import VTS from "~/constants/static";
  * @param next {NextFunction} error handling
  */
 
+interface IData {
+  user: string;
+  header: { additional?: boolean; end?: boolean; qna?: boolean };
+}
+
 export const postSessionGreeting = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const session = req.session as UserSession;
     const UserSessionId = `sess:${req.sessionID}`;
-    const { question, header } = req.body;
-    const { free } = header;
+    const user = `As visual thinking strategy practitioner,${req.body.user}`;
     const currentStage = "/session/greeting";
-    const nextStage = "/vts/init";
-    const result: AxiosResponse = await axios.post(`${FLASK_SERVER}/talk`, { question, header });
+    const nextStage = `/vts/init?additional=true`;
+    const data: IData = { user, header: { additional: false } };
 
-    const answer = result.data.contents.answer;
+    const result: AxiosResponse = await axios.post(`${FLASK_SERVER}/talk`, data);
+
+    const agent = result.data.contents.answer;
     const source = result.data.contents.source;
     const relevantSources = JSON.stringify(result.data.contents.relevantSources);
     await Message.create({
-      question,
-      answer,
+      user,
+      agent,
       source,
       relevantSources,
+      free: false,
       stage: currentStage,
       type: "dynamic",
-      free,
       UserSessionId,
     });
 
@@ -42,72 +48,134 @@ export const postSessionGreeting = async (req: Request, res: Response, next: Nex
 
     return res
       .status(200)
-      .json({ message: "greeting success", question, answer, source, relevantSources, currentStage, nextStage });
+      .json({ message: "greeting success", user, agent, source, relevantSources, currentStage, nextStage });
   } catch (e) {
     next(e);
   }
 };
+
+/**
+ * VTS Introduce and VTS agree
+ * @param req
+ * @param res
+ * @param next
+ * @returns
+ */
 
 export const postVTSInit = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const session = req.session as UserSession;
     const UserSessionId = `sess:${req.sessionID}`;
-    const { question, header } = req.body;
-    const { free } = header;
-    const currentStage = "/vts/init";
-    const nextStage = "/vts/first?additional=true";
-    const answer = VTS.what;
-
-    await Message.create({
-      question,
-      answer,
-      source: "static",
-      relevantSources: "static",
-      stage: currentStage,
-      type: "static",
-      free,
-      UserSessionId,
-    });
+    const { user } = req.body;
+    let additional;
+    if (req.query.additional === "true") additional = true;
+    else if (req.query.additional === "false") additional = false;
+    if (additional === undefined) return res.status(400).json({ message: "incorrect query string" });
+    if (!user) return res.status(400).json({ message: "incorrect data" });
+    const currentStage = `/vts/init?additional=${additional}`;
+    const nextStage = additional ? `/vts/init?additional=${!additional}` : `/vts/first?additional=${!additional}`;
 
     session.user.currentStage = currentStage;
     session.user.nextStage = nextStage;
 
-    return res.status(200).json({
-      message: "greeting success",
-      question,
-      answer,
-      source: "static",
-      relevantSources: "static",
-      currentStage,
-      nextStage,
-    });
+    if (additional) {
+      const agent = VTS.what;
+      await Message.create({
+        user,
+        agent,
+        source: "static",
+        free: false,
+        relevantSources: "static",
+        stage: currentStage,
+        type: "static",
+        UserSessionId,
+      });
+      return res.status(200).json({
+        message: "vts introduce success, please agree with starting to vts session",
+        user,
+        agent,
+        source: "static",
+        relevantSources: "static",
+        currentStage,
+        nextStage,
+      });
+    } else {
+      /**
+        TODO : 자연어 처리 로직 추가 
+      */
+      // const result: AxiosResponse = await axios.post(`${FLASK_SERVER}/talk`, data);
+      const agent = "thank you";
+      const source = "static";
+      const relevantSources = "static";
+      await Message.create({
+        user,
+        agent,
+        source,
+        free: false,
+        relevantSources,
+        stage: currentStage,
+        type: "dynamic",
+        UserSessionId,
+      });
+      return res.status(200).json({
+        message: "vts first init, reply for first vts question",
+        user,
+        agent,
+        first: VTS.first,
+        source: "static",
+        relevantSources: "static",
+        currentStage,
+        nextStage,
+      });
+    }
   } catch (e) {
     next(e);
   }
 };
 
+/**
+ * VTS first session and first additional quesiton
+ * TODO : 그림 정보를 알아내는 자연어 처리 로직 필요
+ * @param req
+ * @param res
+ * @param next
+ * @returns
+ */
+
 export const postVTSFirst = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const session = req.session as UserSession;
     const UserSessionId = `sess:${req.sessionID}`;
-    const { question, header } = req.body;
-    const { additional } = req.query;
-    const { free } = header;
-    const currentStage = "/vts/first";
-    const nextStage = "/vts/first?additional=false";
-    const result: AxiosResponse = await axios.post(`${FLASK_SERVER}/talk`, { question, header });
+    let { user } = req.body;
+    let additional;
+    if (req.query.additional === "true") additional = true;
+    else if (req.query.additional === "false") additional = false;
+    if (additional === undefined) return res.status(400).json({ message: "incorrect query string" });
+    if (!user) return res.status(400).json({ message: "incorrect data" });
+    const currentStage = `/vts/first?additional=${additional}`;
+    const nextStage = additional ? `/vts/first?additional=${!additional}` : `/vts/second?additional=${!additional}`;
 
-    const answer = result.data.contents.answer;
+    if (additional) {
+      user = `As visual thinking strategy practitioner Rephrase the question below and answer it. And create one additional question for it. \n ${user}`;
+    } else {
+      user = `As visual thinking strategy practitioner Rephrase the question below and answer it. \n ${user} `;
+    }
+    const data: IData = { user, header: { additional } };
+
+    const result: AxiosResponse = await axios.post(`${FLASK_SERVER}/talk`, data);
+
+    const agent = result.data.contents.answer;
     const source = result.data.contents.source;
     const relevantSources = JSON.stringify(result.data.contents.relevantSources);
+
     await Message.create({
-      question,
-      answer,
+      user,
+      agent,
       source,
+      free: false,
       relevantSources,
       stage: currentStage,
       type: "dynamic",
-      free,
       UserSessionId,
     });
 
@@ -115,11 +183,11 @@ export const postVTSFirst = async (req: Request, res: Response, next: NextFuncti
     session.user.nextStage = nextStage;
 
     return res.status(200).json({
-      message: "greeting success",
-      question,
-      answer,
-      source: "static",
-      relevantSources: "static",
+      message: additional ? "continue additional question" : "additional question end",
+      user,
+      agent,
+      source,
+      relevantSources,
       currentStage,
       nextStage,
     });

--- a/src/controllers/post.ts
+++ b/src/controllers/post.ts
@@ -22,7 +22,8 @@ export const postSessionGreeting = async (req: Request, res: Response, next: Nex
   try {
     const session = req.session as UserSession;
     const UserSessionId = `sess:${req.sessionID}`;
-    const user = `As visual thinking strategy practitioner,${req.body.user}`;
+    const user = req.body.user;
+    if (!user) return res.status(400).json({ message: "incorrect data" });
     const currentStage = "/session/greeting";
     const nextStage = `/vts/init?additional=true`;
     const data: IData = { user, header: { additional: false } };
@@ -104,7 +105,7 @@ export const postVTSInit = async (req: Request, res: Response, next: NextFunctio
         TODO : 자연어 처리 로직 추가 
       */
       // const result: AxiosResponse = await axios.post(`${FLASK_SERVER}/talk`, data);
-      const agent = "thank you";
+      const agent = "thank you for agreeing";
       const source = "static";
       const relevantSources = "static";
       await Message.create({
@@ -118,7 +119,7 @@ export const postVTSInit = async (req: Request, res: Response, next: NextFunctio
         UserSessionId,
       });
       return res.status(200).json({
-        message: "vts first init, reply for first vts question",
+        message: "vts init, reply for first vts question",
         user,
         agent,
         first: VTS.first,
@@ -155,11 +156,11 @@ export const postVTSFirst = async (req: Request, res: Response, next: NextFuncti
     const currentStage = `/vts/first?additional=${additional}`;
     const nextStage = additional ? `/vts/first?additional=${!additional}` : `/vts/second?additional=${!additional}`;
 
-    if (additional) {
-      user = `As visual thinking strategy practitioner Rephrase the question below and answer it. And create one additional question for it. \n ${user}`;
-    } else {
-      user = `As visual thinking strategy practitioner Rephrase the question below and answer it. \n ${user} `;
-    }
+    // if (additional) {
+    //   user = `As visual thinking strategy practitioner, Rephrase the question below and answer it. And create one additional question for it. \n ${user}`;
+    // } else {
+    //   user = `As visual thinking strategy practitioner, Rephrase the question below and answer it. \n ${user} `;
+    // }
     const data: IData = { user, header: { additional } };
 
     const result: AxiosResponse = await axios.post(`${FLASK_SERVER}/talk`, data);
@@ -183,7 +184,225 @@ export const postVTSFirst = async (req: Request, res: Response, next: NextFuncti
     session.user.nextStage = nextStage;
 
     return res.status(200).json({
-      message: additional ? "continue additional question" : "additional question end",
+      message: additional
+        ? "reply for additional question"
+        : "first additional question end. reply for second VTS session question",
+      user,
+      agent,
+      source,
+      second: !additional && VTS.second,
+      relevantSources,
+      currentStage,
+      nextStage,
+    });
+  } catch (e) {
+    next(e);
+  }
+};
+
+export const postVTSSecond = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const session = req.session as UserSession;
+    const UserSessionId = `sess:${req.sessionID}`;
+    let { user } = req.body;
+    let additional;
+    if (req.query.additional === "true") additional = true;
+    else if (req.query.additional === "false") additional = false;
+    if (additional === undefined) return res.status(400).json({ message: "incorrect query string" });
+    if (!user) return res.status(400).json({ message: "incorrect data" });
+    const currentStage = `/vts/second?additional=${additional}`;
+    const nextStage = additional ? `/vts/second?additional=${!additional}` : `/vts/third?additional=${!additional}`;
+
+    // if (additional) {
+    //   user = `As visual thinking strategy practitioner, Rephrase the question below and answer it. And create one additional question for it. \n ${user}`;
+    // } else {
+    //   user = `As visual thinking strategy practitioner, Rephrase the question below and answer it. \n ${user} `;
+    // }
+    const data: IData = { user, header: { additional } };
+
+    const result: AxiosResponse = await axios.post(`${FLASK_SERVER}/talk`, data);
+
+    const agent = result.data.contents.answer;
+    const source = result.data.contents.source;
+    const relevantSources = JSON.stringify(result.data.contents.relevantSources);
+
+    await Message.create({
+      user,
+      agent,
+      source,
+      free: false,
+      relevantSources,
+      stage: currentStage,
+      type: "dynamic",
+      UserSessionId,
+    });
+
+    session.user.currentStage = currentStage;
+    session.user.nextStage = nextStage;
+
+    return res.status(200).json({
+      message: additional ? "reply for additional question" : "additional question end. reply for third VTS quesiton",
+      user,
+      agent,
+      source,
+      third: !additional && VTS.third,
+      relevantSources,
+      currentStage,
+      nextStage,
+    });
+  } catch (e) {
+    next(e);
+  }
+};
+
+export const postVTSThird = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const session = req.session as UserSession;
+    const UserSessionId = `sess:${req.sessionID}`;
+    let { user } = req.body;
+    let additional;
+    if (req.query.additional === "true") additional = true;
+    else if (req.query.additional === "false") additional = false;
+    if (additional === undefined) return res.status(400).json({ message: "incorrect query string" });
+    if (!user) return res.status(400).json({ message: "incorrect data" });
+    const currentStage = `/vts/third?additional=${additional}`;
+    const nextStage = additional ? `/vts/third?additional=${!additional}` : `/vts/end`;
+
+    // if (additional) {
+    //   user = `As visual thinking strategy practitioner, Rephrase the question below and answer it. And create one additional question for it. \n ${user}`;
+    // } else {
+    //   user = `As visual thinking strategy practitioner, Rephrase the question below and answer it. \n ${user} `;
+    // }
+    const data: IData = { user, header: { additional } };
+
+    const result: AxiosResponse = await axios.post(`${FLASK_SERVER}/talk`, data);
+
+    const agent = result.data.contents.answer;
+    const source = result.data.contents.source;
+    const relevantSources = JSON.stringify(result.data.contents.relevantSources);
+
+    await Message.create({
+      user,
+      agent,
+      source,
+      free: false,
+      relevantSources,
+      stage: currentStage,
+      type: "dynamic",
+      UserSessionId,
+    });
+
+    session.user.currentStage = currentStage;
+    session.user.nextStage = nextStage;
+
+    return res.status(200).json({
+      message: additional ? "reply for third additional question" : "VTS session end",
+      user,
+      agent,
+      source,
+      end: !additional && VTS.evaluate,
+      relevantSources,
+      currentStage,
+      nextStage,
+    });
+  } catch (e) {
+    next(e);
+  }
+};
+
+export const postVTSEnd = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const session = req.session as UserSession;
+    const UserSessionId = `sess:${req.sessionID}`;
+    let { user } = req.body;
+    if (!user) return res.status(400).json({ message: "incorrect data" });
+    const currentStage = `/vts/end`;
+    const nextStage = `/qna?additional=true`;
+
+    // if (additional) {
+    //   user = `As visual thinking strategy practitioner, Rephrase the question below and answer it. And create one additional question for it. \n ${user}`;
+    // } else {
+    //   user = `As visual thinking strategy practitioner, Rephrase the question below and answer it. \n ${user} `;
+    // }
+
+    const agent = "none";
+    const source = `user's response`;
+    const relevantSources = `user's response`;
+
+    await Message.create({
+      user,
+      agent,
+      source,
+      free: false,
+      relevantSources,
+      stage: currentStage,
+      type: "dynamic",
+      UserSessionId,
+    });
+
+    session.user.currentStage = currentStage;
+    session.user.nextStage = nextStage;
+
+    return res.status(200).json({
+      message: "Thank you for participating in the evaluation.",
+      user,
+      agent,
+      source,
+      relevantSources,
+      currentStage,
+      nextStage,
+    });
+  } catch (e) {
+    next(e);
+  }
+};
+
+export const postQNA = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const session = req.session as UserSession;
+    const UserSessionId = `sess:${req.sessionID}`;
+    let { user } = req.body;
+    let additional;
+    if (req.query.additional === "true") additional = true;
+    else if (req.query.additional === "false") additional = false;
+    if (additional === undefined) return res.status(400).json({ message: "incorrect query string" });
+    else if (additional === false) return res.status(200).json({ message: "End the Q&A" });
+    if (!user) return res.status(400).json({ message: "incorrect data" });
+
+    const currentStage = `/qna?additional=${additional}`;
+    const nextStage = `/qna?additional=`;
+
+    // if (additional) {
+    //   user = `As visual thinking strategy practitioner, Rephrase the question below and answer it. And create one additional question for it. \n ${user}`;
+    // } else {
+    //   user = `As visual thinking strategy practitioner, Rephrase the question below and answer it. \n ${user} `;
+    // }
+
+    const data: IData = { user, header: { additional } };
+
+    const result: AxiosResponse = await axios.post(`${FLASK_SERVER}/talk`, data);
+
+    const agent = result.data.contents.answer;
+    const source = result.data.contents.source;
+    const relevantSources = JSON.stringify(result.data.contents.relevantSources);
+
+    await Message.create({
+      user,
+      agent,
+      source,
+      free: false,
+      relevantSources,
+      stage: currentStage,
+      type: "dynamic",
+      UserSessionId,
+    });
+
+    session.user.currentStage = currentStage;
+    session.user.nextStage = nextStage;
+
+    return res.status(200).json({
+      message:
+        "If you want to continue the query, send another request to the same endpoint with the query string additional value of true.",
       user,
       agent,
       source,

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -7,8 +7,8 @@ class Message extends Model {
   public type: string;
   public free: boolean;
   public stage: string;
-  public question: string;
-  public answer: string;
+  public user: string;
+  public agent: string;
   public source: string;
   public relevantSource: string;
   public readonly createAt!: Date;
@@ -29,11 +29,11 @@ Message.init(
       type: DataTypes.STRING(50),
       allowNull: false,
     },
-    question: {
+    user: {
       type: DataTypes.TEXT,
       allowNull: false,
     },
-    answer: {
+    agent: {
       type: DataTypes.TEXT,
       allowNull: false,
     },

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -1,5 +1,13 @@
 import express from "express";
-import { postSessionGreeting, postVTSInit, postVTSFirst } from "~/controllers";
+import {
+  postSessionGreeting,
+  postVTSInit,
+  postVTSFirst,
+  postVTSSecond,
+  postVTSThird,
+  postVTSEnd,
+  postQNA,
+} from "~/controllers";
 import { isSessionInit } from "~/lib/middlewares";
 
 const postRouter = express.Router();
@@ -7,5 +15,10 @@ const postRouter = express.Router();
 postRouter.post("/session/greeting", isSessionInit, postSessionGreeting);
 postRouter.post("/vts/init", isSessionInit, postVTSInit);
 postRouter.post("/vts/first", isSessionInit, postVTSFirst);
+postRouter.post("/vts/second", isSessionInit, postVTSSecond);
+postRouter.post("/vts/third", isSessionInit, postVTSThird);
+postRouter.post("/vts/end", isSessionInit, postVTSEnd);
+
+postRouter.post("/qna", isSessionInit, postQNA);
 
 export default postRouter;

--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -1,10 +1,11 @@
 import express from "express";
-import { postSessionGreeting, postVTSInit } from "~/controllers";
+import { postSessionGreeting, postVTSInit, postVTSFirst } from "~/controllers";
 import { isSessionInit } from "~/lib/middlewares";
 
 const postRouter = express.Router();
 
 postRouter.post("/session/greeting", isSessionInit, postSessionGreeting);
 postRouter.post("/vts/init", isSessionInit, postVTSInit);
+postRouter.post("/vts/first", isSessionInit, postVTSFirst);
 
 export default postRouter;


### PR DESCRIPTION
# 요약
- VTS 세션 단계 별로 쿼리 스트링에 따라 로직 처리

# 상세
- end point 로 한번 구분하고 additional 이라는 쿼리 스트링을 통해서 단계를 구분합니다.
- vts init 에서는 정적 데이터가 두번 통신합니다. 이 경우에 2차 프로토 타입이라 자연어 처리가 없어서 해당 방식으로 진행됩니다.
- vts first ~ third 에서는 additional 여부에 따라 추가 질문이 붙거나 다음 세션으로 넘어 갑니다.

아직 first 를 끝내지 못했지만,  VTS first 만 되면 같은 방식으로 third 까지 연결이 가능하기 떄문에 금방 진행할 것으로 예상함.

# 이슈
- Flask llm 에서 전체에 대한 context 를 알고 있어야 유저 질문에 대한 답변을 openai 가 처리하는데 이 부분에 대한 방법 필요
- API 문서 수정 사항이 있으니 참조 부탁드립니다. @asiloveyou 
  https://www.notion.so/HCI-software-API-document-9afa861c0b4b4fbf981dffb3186d20fb?pvs=4
